### PR TITLE
fix DeprecationWarning for numpy 1.25+

### DIFF
--- a/castepxbin/ome_bin.py
+++ b/castepxbin/ome_bin.py
@@ -81,7 +81,7 @@ def read_cst_ome(fname, num_bands, num_kpoints, num_spins, endian='big'):
                     for ib1 in range(num_bands):
                         for ib2 in range(num_bands):
                             om[si, ki, idx, ib1, ib2] = fhandle.read_record(
-                                elem)
+                                elem).item()
         out = fhandle._fp.read()  # pylint: disable=protected-access
         assert out == b"", "More data exist beyond the specified sizes."
     return om


### PR DESCRIPTION
While running code that uses the `castepxbin` package, I encountered the following warning:

```log
DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
    om[si, ki, idx, ib1, ib2] = fhandle.read_record(
```

This suggests that `fhandle.read_record()` returns a NumPy array with `ndim > 0`, but the assignment is treating it like a scalar. This behavior is deprecated in NumPy 1.25 and will raise an error in future versions.